### PR TITLE
Ability to escape equal signs in parameter value

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,12 +17,12 @@ function preprocess (argv) {
 		arg = argv[i];
 		var parts = arg.match(/(.+)[^\\]=(.+)/);
 		if (parts) {
-            argv.splice(i, 1, parts[1], parts[2]);
+	            argv.splice(i, 1, parts[1], parts[2]);
 		}
-
-        if(arg.match(/\\=/)){
-            argv.splice(i, 1, arg.replace(/\\=/g, '='));
-        }
+	
+	        if(arg.match(/\\=/)){
+	            argv.splice(i, 1, arg.replace(/\\=/g, '='));
+	        }
 	}
 
 	return argv;


### PR DESCRIPTION
Is there a reason you split on equal signs?

https://github.com/sgmonda/stdio/blob/master/main.js#L18

I am using this on a recent project and needed to be able to pass a url as an option (with get parameters) and this threw me for a loop.

I change that check to this:

https://github.com/truckingsim/stdio/blob/master/main.js#L18-L25

Which lets me escape equal signs if I prepend a `\` in front of the equal sign.  Let me know if you see anything wrong with this.
