### PR TITLE
Update getopt.js

### DIFF
--- a/lib/getopt.js
+++ b/lib/getopt.js
@@ -264,7 +264,7 @@ function getopt (config, helpTail, argv, testing) {
 		// Check all required arguments have been specified for each option
 		var requiredArgumentsCount = config[option].args;
 		var providedArgumentsCount = cmdOptions[option] === true ? 0 : (Array.isArray(cmdOptions[option]) ? cmdOptions[option].length : 1);
-		if (requiredArgumentsCount > 1 && providedArgumentsCount !== requiredArgumentsCount) {
+		if (requiredArgumentsCount >= 1 && providedArgumentsCount !== requiredArgumentsCount) {
 			if (testing) {
 				return null;
 			}


### PR DESCRIPTION
args: 1 do not get checked as a required argument. Change the comparison to also check for args: 1

For a non-mandatory opt, for example:

```
'component' : {key: 'm', description: 'Only generate release notes with specified comma separated component(s) listed', args: 1}
```

The argument will not printhelp instead if -m is sent without a value, then the value is true--but instead should error.
