### PR TITLE
Defaul value support

### DIFF
--- a/src/ask.ts
+++ b/src/ask.ts
@@ -2,10 +2,8 @@ const DEFAULT_MAX_RETRIES = 3;
 
 export interface AskConfig {
   options?: string[];
-  /** Default: 3*/
   maxRetries?: number;
   inputStream?: any;
-  /** Index of the option to be made the default option. Underlines option set as default in console */
   defaultIndex?: number;
 }
 

--- a/src/ask.ts
+++ b/src/ask.ts
@@ -4,6 +4,7 @@ export interface AskConfig {
   options?: string[];
   maxRetries?: number;
   inputStream?: any;
+  /** Index of the option to be made the default option */
   defaultIndex?: number;
 }
 

--- a/src/ask.ts
+++ b/src/ask.ts
@@ -2,19 +2,29 @@ const DEFAULT_MAX_RETRIES = 3;
 
 export interface AskConfig {
   options?: string[];
+  /** Default: 3*/
   maxRetries?: number;
   inputStream?: any;
+  /** Index of the option to be made the default option. Underlines option set as default in console */
+  defaultIndex?: number;
 }
 
 function getInputStream(config: AskConfig): any {
   return config.inputStream || process.stdin;
 }
 
+function isInArrBounds(arr: Array<any> | undefined, index: number | undefined): boolean {
+  return arr !== undefined && index !== undefined && index >= 0 && index <= arr.length - 1;
+}
+
 function print(text: string, config: AskConfig): void {
   const inputStream = getInputStream(config);
   if (inputStream !== process.stdin) return;
-  const { options } = config;
-  if (options) text += ' [' + options.join('/') + ']';
+  const { options, defaultIndex } = config;
+  if (options) {
+    if (defaultIndex && isInArrBounds(options, defaultIndex)) text += ' (default ' + options[defaultIndex] + ')';
+    text += ' [' + options.join('/') + ']';
+  }
   text += ': ';
   process.stdout.write(text);
 }
@@ -39,8 +49,12 @@ function getListener(question: string, config: AskConfig, callback: Function): (
   const onError = getOnError(question, config, callback);
 
   function listener(data: string): void {
-    const answer = data.toString().trim();
-    if (config.options && !config.options.includes(answer)) return onError(listener, --tries);
+    let answer = data.toString().trim();
+    if (config.options && !config.options.includes(answer)) {
+      if (isInArrBounds(config.options, config.defaultIndex)) {
+        answer = config.options[config.defaultIndex as number].toString().trim();
+      } else return onError(listener, --tries);
+    }
     inputStream.removeListener('data', listener);
     inputStream.pause();
     callback('', answer);

--- a/src/ask.ts
+++ b/src/ask.ts
@@ -50,7 +50,7 @@ function getListener(question: string, config: AskConfig, callback: Function): (
   function listener(data: string): void {
     let answer = data.toString().trim();
     if (config.options && !config.options.includes(answer)) {
-      if (isInArrBounds(config.options, config.defaultIndex)) {
+      if (isInArrBounds(config.options, config.defaultIndex) && answer === '') {
         answer = config.options[config.defaultIndex as number].toString().trim();
       } else return onError(listener, --tries);
     }


### PR DESCRIPTION
Added optional AskConfig param `defaultIndex`.
Used to specify the Index of the option (from options param) to be made the default.

Properly handles when index is defined and options isn't.

example question with config:
`const foo = await ask('Would you like some ice cream?, {options: ["yes", "no"], default: 0});`

which will produce:

`Would you like some ice cream? (default yes): [yes/no]`

Pressing enter without typing an answer will automatically select the default.

typing incorrectly, such as 'yws', or a non-answer will still register as failure.

I tested colors/underlining, which looks better, but I didn't feel that it would be consistent across environments (powershell, cmd, bash) and systems, so I went for the (default {option}) approach.