### PR TITLE
Bugfix: Arg with asterisk passed as last parameter

### DIFF
--- a/src/getopt.ts
+++ b/src/getopt.ts
@@ -4,19 +4,19 @@ const ERROR_PREFFIX = 'ERROR#GETOPT: ';
 
 export interface Config {
   [key: string]:
-    | {
-        key?: string;
-        description?: string;
-        multiple?: boolean;
-        args?: number | string;
-        mandatory?: boolean; // @deprecated
-        required?: boolean;
-        default?: string | string[] | boolean;
-        maxArgs?: number;
-        minArgs?: number;
-      }
-    | boolean
-    | undefined;
+  | {
+    key?: string;
+    description?: string;
+    multiple?: boolean;
+    args?: number | string;
+    mandatory?: boolean; // @deprecated
+    required?: boolean;
+    default?: string | string[] | boolean;
+    maxArgs?: number;
+    minArgs?: number;
+  }
+  | boolean
+  | undefined;
 }
 
 export interface Options {
@@ -139,13 +139,13 @@ function getopt(config: Config = {}, command: string[]): GetoptResponse {
     optionArgs: [],
     isMultiple: false,
   };
-  rawArgs.forEach(arg => {
+  rawArgs.forEach((arg, index) => {
     const parsedOption = parseOption(config, arg);
     if (!parsedOption) {
       if (state.activeOption) {
         state.optionArgs.push(arg);
         state.remainingArgs--;
-        if (!state.remainingArgs || state.isMultiple) {
+        if (!state.remainingArgs || state.isMultiple || index === rawArgs.length - 1) {
           const isMultiple = state.isMultiple;
           const partial = getStateAndReset(state);
           Object.entries(partial).forEach(([key, value]) => {
@@ -229,9 +229,9 @@ function getHelpMessage(config: Config, programName: string): string {
     lines.push([
       '  ' + (value.key ? '-' + value.key + ', --' : '--') + key + ops,
       (value.description || '') +
-        (value.mandatory || value.required ? ' (required)' : '') +
-        (value.multiple ? ' (multiple)' : '') +
-        (value.default ? ' ("' + value.default + '" by default)' : ''),
+      (value.mandatory || value.required ? ' (required)' : '') +
+      (value.multiple ? ' (multiple)' : '') +
+      (value.default ? ' ("' + value.default + '" by default)' : ''),
     ]);
   });
 
@@ -267,7 +267,7 @@ function checkConfig(config: Config): void {
     if (!value || typeof value !== 'object') {
       console.warn(
         'Boolean description of getopt() options is deprecated and will be ' +
-          'removed in a future "stdio" release. Please, use an object definitions instead.',
+        'removed in a future "stdio" release. Please, use an object definitions instead.',
       );
       return;
     }
@@ -275,7 +275,7 @@ function checkConfig(config: Config): void {
     if (value.mandatory)
       console.warn(
         '"mandatory" option is deprecated and will be removed in a ' +
-          'future "stdio" release. Please, use "required" instead.',
+        'future "stdio" release. Please, use "required" instead.',
       );
   });
 }

--- a/test/getopt.spec.ts
+++ b/test/getopt.spec.ts
@@ -109,6 +109,11 @@ const TEST_CASES = [
     config: { meta: { args: '*' }, other: { key: 'o' } },
   },
   {
+    command: 'node program.js --bar bar foo',
+    expected: { bar: ['bar', 'foo'] },
+    config: { bar: { args: '*' } },
+  },
+  {
     command: 'node program.js --other',
     expected: { other: true, meta: 'foo' },
     config: { meta: { key: 'm', default: 'foo' }, other: true },


### PR DESCRIPTION
## Bug

Fix this #46 

## Brief description

Has been added a condition to check if is last `rawParameter` to save it in `result` variable, by this way we can use an asterisk arg alone or as last parameter. Also has been added the tests to it.

## Screenshots

![image](https://user-images.githubusercontent.com/55498940/198391004-b6cf7c76-88c0-4810-bbd1-e7c2ac3e36db.png)
